### PR TITLE
Clean up setup.py

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
   # same file set which has already passed, etc.
   pre_job:
     name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -40,7 +40,7 @@ jobs:
     needs: pre_job
     if: "${{ needs.pre_job.outputs.should_skip != 'true' }}"
     name: 'Lint checks - ${{ matrix.python-version }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
     needs: pre_job
     if: "${{ needs.pre_job.outputs.should_skip != 'true' }}"
     name: 'Unit tests - ${{ matrix.python-version }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -96,7 +96,7 @@ jobs:
     needs: pre_job
     if: "${{ needs.pre_job.outputs.should_skip != 'true' }}"
     name: 'Integration tests - ${{ matrix.python-version }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-hvac>=0.9.0
+hvac>=0.9.0,<1.0 # we are using deprecated auth methods removed in 1.0

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,8 @@ import os
 
 from setuptools import setup, find_packages
 
-from dist_utils import check_pip_version
 from dist_utils import fetch_requirements
 from dist_utils import parse_version_string
-
-check_pip_version()
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
@@ -44,10 +41,10 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Intended Audience :: Developers',
         'Environment :: Console',
     ],

--- a/st2auth_vault_backend/__init__.py
+++ b/st2auth_vault_backend/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     'VaultAuthenticationBackend'
 ]
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,5 +9,6 @@ pylint-plugin-utils>=0.4
 pylint==1.9.4
 rednose
 st2flake8==0.1.0
+flake8<5  # st2flake8 does not support flake8 5
 tox==3.14.1
 unittest2


### PR DESCRIPTION
Drop problematic pip version check that can break pants/pex lockfile generation. Also, update python classifiers to 3.6-3.8 and bump the version.

Also constraint a few versions to fix CI breakage.
We should remove py2.7 from CI in a separate PR.